### PR TITLE
Remove Icon style on Doze

### DIFF
--- a/doze/res/values/styles.xml
+++ b/doze/res/values/styles.xml
@@ -18,20 +18,12 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <style name="Theme.Main" parent="@android:style/Theme.DeviceDefault.Settings">
         <item name="dialogPreferenceStyle">@style/Theme.Main.DialogPreferenceStyle</item>
-        <item name="preferenceCategoryStyle">@style/Theme.Main.PreferenceCategoryStyle</item>
         <item name="preferenceFragmentStyle">@style/Theme.Main.PreferenceFragmentStyle</item>
         <item name="preferenceStyle">@style/Theme.Main.PreferenceStyle</item>
         <item name="preferenceTheme">@style/Theme.Main.PreferenceTheme</item>
-        <item name="switchPreferenceStyle">@style/Theme.Main.SwitchPreferenceStyle</item>
     </style>
 
     <style name="Theme.Main.DialogPreferenceStyle" parent="@style/Theme.Main.PreferenceStyle">
-    </style>
-
-    <style name="Theme.Main.PreferenceCategoryStyle" parent="@*android:style/Preference.DeviceDefault.Category">
-        <item name="allowDividerAbove">true</item>
-        <item name="allowDividerBelow">true</item>
-        <item name="android:layout">@layout/preference_category_material_settings</item>
     </style>
 
     <style name="Theme.Main.PreferenceFragmentStyle" parent="@*android:style/PreferenceFragment.Material">
@@ -46,10 +38,6 @@
     </style>
 
     <style name="Theme.Main.PreferenceTheme">
-    </style>
-
-    <style name="Theme.Main.SwitchPreferenceStyle" parent="@style/Theme.Main.PreferenceStyle">
-        <item name="widgetLayout">@*android:layout/preference_widget_switch</item>
     </style>
 
     <style name="Theme.Main.SwitchBar" parent="@android:style/ThemeOverlay.Material.ActionBar">


### PR DESCRIPTION
This must fix the wrong icon style of the Ambient Display menu. Thanks to **Sube Zhj** for his help on fix.
To be tested on JDC Pie Gsi.